### PR TITLE
Make package work with react native 0.47 by removing createJSModules

### DIFF
--- a/android/src/main/java/com/github/wumke/RNExitApp/RNExitAppPackage.java
+++ b/android/src/main/java/com/github/wumke/RNExitApp/RNExitAppPackage.java
@@ -24,12 +24,6 @@ public class RNExitAppPackage implements ReactPackage {
     }
 
     @Override
-    public List<Class<? extends JavaScriptModule>> createJSModules() {
-
-        return Collections.emptyList();
-    }
-
-    @Override
     public List<ViewManager> createViewManagers(
             ReactApplicationContext reactContext) {
         return Collections.emptyList();


### PR DESCRIPTION
createJSModules was removed in react native 0.47 (https://github.com/facebook/react-native/releases/tag/v0.47.0)