### PR TITLE
fixing the mis-reference to another project

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 Exit / Close / Kill / shutdown your react native app. Does not invoke a crash notification.
 
 NOTICE:
-- for React Native < 0.47 use react-native-immediate-phone-call <1.x.x
-- for React Native > 0.47 use react-native-immediate-phone-call >=1.x.x
+- for React Native < 0.47 use react-native-exit-app <1.x.x
+- for React Native > 0.47 use react-native-exit-app >=1.x.x
 
 ## Setup
 


### PR DESCRIPTION
the README file referenced the "react-native-immediate-phone-call" project in the NOTICE section, when it should have referenced the "react-native-exit-app" project