### PR TITLE
Add `s.dependency 'React'` to avoid error when `pod install` using co…

### DIFF
--- a/react-native-exit-app.podspec
+++ b/react-native-exit-app.podspec
@@ -30,6 +30,6 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
   # s.xcconfig = { "HEADER_SEARCH_PATHS" => "$(SDKROOT)/usr/include/libxml2" }
-  
+  s.dependency 'React'
 
 end


### PR DESCRIPTION
Add `s.dependency 'React'` to avoid error when `pod install` using cocoapods `>= 1.5.0`.
Error list blow:

```
In file included from /Users/OceanHorn/SourceTree/mobile-agent/node_modules/react-native-exit-app/ios/RNExitApp/RNExitApp.m:2:
/Users/OceanHorn/SourceTree/mobile-agent/node_modules/react-native/React/Base/RCTBridgeModule.h:10:9: fatal error: 'React/RCTDefines.h' file not found
#import <React/RCTDefines.h>
        ^~~~~~~~~~~~~~~~~~~~
1 error generated.
```