### PR TITLE
Fix for Execution failed for task ':react-native-exit-app:verifyReleaseResources'. #24

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,16 +1,27 @@
+buildscript {
+    repositories {
+        jcenter()
+        google()
+    }
+
+    dependencies {
+        classpath 'com.android.tools.build:gradle:3.1.4'
+    }
+}
+
+def safeExtGet(prop, fallback) {
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 apply plugin: 'com.android.library'
 
-def DEFAULT_COMPILE_SDK_VERSION = 23
-def DEFAULT_BUILD_TOOLS_VERSION = "25.0.0"
-def DEFAULT_TARGET_SDK_VERSION  = 22
-
 android {
-    compileSdkVersion project.hasProperty('compileSdkVersion') ? project.compileSdkVersion : DEFAULT_COMPILE_SDK_VERSION
-    buildToolsVersion project.hasProperty('buildToolsVersion') ? project.buildToolsVersion : DEFAULT_BUILD_TOOLS_VERSION
+    compileSdkVersion safeExtGet('compileSdkVersion', 23)
+    buildToolsVersion safeExtGet('buildToolsVersion', "25.0.0")
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion hasProperty('targetSdkVersion') ? project.targetSdkVersion : DEFAULT_TARGET_SDK_VERSION
+        minSdkVersion safeExtGet('minSdkVersion',16)
+        targetSdkVersion safeExtGet('targetSdkVersion',22)
         versionCode 2
         versionName "1.1"
         ndk {


### PR DESCRIPTION
Fix fir #24 
https://github.com/wumke/react-native-exit-app/issues/24

updated Build.gradle(app) to use global project settings. 