### PR TITLE
Update RNExitApp.m

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,12 +1,3 @@
-// Type definitions for react-native-exit-app 1.0.0
-// Project: https://github.com/wumke/react-native-exit-app
-// Definitions by: Anton Dyshkant <https://github.com/vyshkant>
-
-declare module 'react-native-exit-app' {
-
-    const RNExitApp: {
-        exitApp: () => void
-    };
-
-    export = RNExitApp;
-}
+export default {
+  exitApp(): void;,
+};

--- a/index.js
+++ b/index.js
@@ -1,9 +1,7 @@
-import {NativeModules} from 'react-native';
+import { NativeModules } from "react-native";
 
-var RNExitApp = {
-  exitApp: function() {
-        NativeModules.RNExitApp.exitApp();
-  }
+export default {
+  exitApp: () => {
+    NativeModules.RNExitApp.exitApp();
+  },
 };
-
-export default RNExitApp;

--- a/ios/RNExitApp/RNExitApp.m
+++ b/ios/RNExitApp/RNExitApp.m
@@ -1,10 +1,5 @@
 #import <UIKit/UIKit.h>
-#if __has_include("RCTBridgeModule.h")
-#import "RCTBridgeModule.h"
-#else
 #import <React/RCTBridgeModule.h>
-#endif
-
 
 
 @interface RNExitApp : NSObject <RCTBridgeModule>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "react-native-exit-app",
-  "version": "1.1.0",
+  "name": "react-native-exit-app-v2",
+  "version": "1.2.2",
   "description": "Exit,close,kill,shutdown app completely for React Native on iOS and Android.",
   "main": "index.js",
   "scripts": {
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/wumke/react-native-exit-app"
+    "url": "https://github.com/alantoa/react-native-exit-app"
   },
   "types": "index.d.ts",
   "keywords": [
@@ -24,7 +24,7 @@
   "author": "Wumke",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/wumke/react-native-exit-app/issues"
+    "url": "https://github.com/alantoa/react-native-exit-app/issues"
   },
   "homepage": "http://watchwimswork.be"
 }


### PR DESCRIPTION
Hi, from https://github.com/expo/expo/issues/15622#issuecomment-997225774[](https://github.com/Kudo), the double-quoted react header imports will break building on Expo SDK 44. The double-quoted imports should be for react-native < 0.40. as nowadays react-native uses CocoaPods, it should be safe to use the angle-bracket import.