### PR TITLE
replaced jcenter by mavenCentral to fix build

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     if (project == rootProject) {
         repositories {
             google()
-            jcenter()
+            mavenCentral()
         }
 
         dependencies {


### PR DESCRIPTION
`jcenter` is deprecated and apps should use `mavenCentral` as the new repository

closes #50 